### PR TITLE
[Fixes #121866309]

### DIFF
--- a/addon/components/accordion-toggle.js
+++ b/addon/components/accordion-toggle.js
@@ -14,6 +14,13 @@ const AccordionToggleComponent = Ember.Component.extend(ElementActiveState, {
   click: function() {
     if(!this.get('isDisabled')) {
       this.get('accordion').toggleClick(this.getProperties('listId', 'itemId', 'panelName'));
+
+      // Offset the page by one pixel about 250ms later to force rerender in
+      // Safari to remove a strange render bug.
+      // TODO: Figure out a way to fix this that isn't coupled to a CSS selector.
+      Ember.run.later('Accordion Click', function() {
+        $('#content').offset({ top: $('#content').offset().top - 1 });
+      }, 250);
     }
     return false;
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ember-accordion",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "An ember accordion component that makes 'fancy' accordions easy.",
   "directories": {
     "test": "tests"


### PR DESCRIPTION
Offset the page by one pixel about 250ms later to force rerender in Safari to remove a strange render bug.

TODO: Figure out a way to fix this that isn't coupled to a CSS selector.

@chbonser if this method bothers you, I can continue looking for a better solution.