### PR TITLE
Avoid deprecation warning by updating `ember-cli-htmlbars`

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "broccoli-merge-trees": "^0.2.1",
     "broccoli-static-compiler": "^0.2.1",
     "ember-cli-babel": "^5.0.0",
-    "ember-cli-htmlbars": "0.7.9",
+    "ember-cli-htmlbars": "1.0.8",
     "ember-cli-sass": "^5.2.1"
   },
   "ember-addon": {


### PR DESCRIPTION
Pre 1.0 `ember-cli-htmlbars` does not use `_super` from `init` in a way that Ember likes.