### PR TITLE
Remove positional params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Upcoming (0.6.0)
 
 - Update circle config settings
+- Remove the internal use of positional params. These params were not intended to
+  be part of the public interface so this should be a non-breaking change for most
+  users.
 
 ## Breaking Changes
 

--- a/addon/components/accordion-item.js
+++ b/addon/components/accordion-item.js
@@ -1,35 +1,33 @@
-import { notEmpty } from '@ember/object/computed';
-import Component from '@ember/component';
-import { computed } from '@ember/object';
-import layout from '../templates/components/accordion-item';
+import { notEmpty } from "@ember/object/computed";
+import Component from "@ember/component";
+import { computed } from "@ember/object";
+import layout from "../templates/components/accordion-item";
 
-const AccordionItemComponent = Component.extend({
+export default Component.extend({
   layout,
   classNames: ["AccordionItem"],
 
-  itemId: computed(function() { return this.elementId; }),
-
-  // item is active if there is an item in activeItems matching 'itemId'
-  isActive: notEmpty('ownActiveItem'),
-  ownActiveItem: computed('activeItems.@each.id', 'itemId', function() {
-    return this.get('activeItems').findBy('id', this.get('itemId'));
+  itemId: computed(function() {
+    return this.elementId;
   }),
 
-  activePanel: computed('isActive', 'ownActiveItem.panel', function() {
-    if(!this.get('isActive')) { return null; }
+  // item is active if there is an item in activeItems matching 'itemId'
+  isActive: notEmpty("ownActiveItem"),
+  ownActiveItem: computed("activeItems.@each.id", "itemId", function() {
+    return this.get("activeItems").findBy("id", this.get("itemId"));
+  }),
 
-    return this.get('ownActiveItem.panel');
+  activePanel: computed("isActive", "ownActiveItem.panel", function() {
+    if (!this.get("isActive")) {
+      return null;
+    }
+
+    return this.get("ownActiveItem.panel");
   }),
 
   actions: {
     togglePanel(panelName) {
-      this.get('toggle')(this.get('itemId'), panelName);
+      this.get("toggle")(this.get("itemId"), panelName);
     }
   }
 });
-
-AccordionItemComponent.reopenClass({
-  positionalParams: ['activeItems']
-});
-
-export default AccordionItemComponent;

--- a/addon/components/accordion-list.js
+++ b/addon/components/accordion-list.js
@@ -1,11 +1,11 @@
-import { A } from '@ember/array';
-import Component from '@ember/component';
-import { computed } from '@ember/object';
-import { isNone, isEqual } from '@ember/utils';
-import layout from '../templates/components/accordion-list';
-import Item from '../utils/item';
+import { A } from "@ember/array";
+import Component from "@ember/component";
+import { computed } from "@ember/object";
+import { isNone, isEqual } from "@ember/utils";
+import layout from "../templates/components/accordion-list";
+import Item from "../utils/item";
 
-const AccordionListComponent = Component.extend({
+export default Component.extend({
   layout,
   classNames: ["AccordionList"],
 
@@ -17,34 +17,43 @@ const AccordionListComponent = Component.extend({
   _registeredItems: null,
   init() {
     this._super(...arguments);
-    this.set('_activeItems', A([]));
-    this.set('_registeredItems', A([]));
+    this.set("_activeItems", A([]));
+    this.set("_registeredItems", A([]));
   },
 
   // If each registered item has at least on panel open, then return true
-  allExpanded: computed('_activeItems.[]', '_registeredItems.[]', function() {
-    let { _activeItems, _registeredItems } = this.getProperties('_activeItems', '_registeredItems');
+  allExpanded: computed("_activeItems.[]", "_registeredItems.[]", function() {
+    let { _activeItems, _registeredItems } = this.getProperties(
+      "_activeItems",
+      "_registeredItems"
+    );
 
-    let anyMissing = _registeredItems.reduce((anyMissing, item) => anyMissing || isNone(_activeItems.findBy('id', item.itemId)), false);
+    let anyMissing = _registeredItems.reduce(
+      (anyMissing, item) =>
+        anyMissing || isNone(_activeItems.findBy("id", item.itemId)),
+      false
+    );
     return !anyMissing;
   }),
 
   actions: {
     toggleItem(itemId, panelName) {
-      const activeItems = this.get('_activeItems');
-      const targetItem = activeItems.findBy('id', itemId);
+      const activeItems = this.get("_activeItems");
+      const targetItem = activeItems.findBy("id", itemId);
 
       // if target item is already active
-      if(targetItem) {
+      if (targetItem) {
         // and the panel is already active
-        if(isEqual(targetItem.get('panel'), panelName)) {
+        if (isEqual(targetItem.get("panel"), panelName)) {
           activeItems.removeObject(targetItem);
         } else {
-          targetItem.set('panel', panelName);
+          targetItem.set("panel", panelName);
         }
       } else {
         // if simultanious active items are not allow, clear array
-        if(!this.get('allowManyActiveItems')) { activeItems.clear(); }
+        if (!this.get("allowManyActiveItems")) {
+          activeItems.clear();
+        }
 
         let newItem = Item.create({ id: itemId, panel: panelName });
         activeItems.addObject(newItem);
@@ -52,35 +61,38 @@ const AccordionListComponent = Component.extend({
     },
 
     closeItem(itemId) {
-      let activeItems = this.get('_activeItems');
-      const activeItem = activeItems.findBy('id', itemId);
+      let activeItems = this.get("_activeItems");
+      const activeItem = activeItems.findBy("id", itemId);
       activeItems.removeObject(activeItem);
     },
 
     expandAll(panelName) {
-      panelName = panelName || 'panel-one';
-      let { _activeItems, _registeredItems } = this.getProperties('_activeItems', '_registeredItems');
+      panelName = panelName || "panel-one";
+      let { _activeItems, _registeredItems } = this.getProperties(
+        "_activeItems",
+        "_registeredItems"
+      );
       _registeredItems.forEach(registeredItem => {
         if (registeredItem.panelName === panelName) {
-          _activeItems.addObject(Item.create({id: registeredItem.itemId, panel: panelName}));
+          _activeItems.addObject(
+            Item.create({ id: registeredItem.itemId, panel: panelName })
+          );
         }
       });
     },
 
     collapseAll() {
-      this.get('_activeItems').clear();
+      this.get("_activeItems").clear();
     },
 
     // private action, allow panel's to register themselves so they can participate in expand/collapse all
     register(itemId, panelName) {
-      this.get('_registeredItems').addObject({itemId, panelName});
+      this.get("_registeredItems").addObject({ itemId, panelName });
     },
 
     // private action
     unregister(itemId, panelName) {
-      this.get('_registeredItems').removeObject({itemId, panelName});
-    },
+      this.get("_registeredItems").removeObject({ itemId, panelName });
+    }
   }
 });
-
-export default AccordionListComponent;

--- a/addon/components/accordion-panel.js
+++ b/addon/components/accordion-panel.js
@@ -1,44 +1,40 @@
-import { next } from '@ember/runloop';
-import Component from '@ember/component';
-import { computed } from '@ember/object';
-import { isEqual } from '@ember/utils';
-import layout from '../templates/components/accordion-panel';
+import { next } from "@ember/runloop";
+import Component from "@ember/component";
+import { computed } from "@ember/object";
+import { isEqual } from "@ember/utils";
+import layout from "../templates/components/accordion-panel";
 
-const AccordionPanelComponent = Component.extend({
+export default Component.extend({
   layout,
   classNames: ["AccordionPanel"],
-  classNameBindings: ['isActive'],
+  classNameBindings: ["isActive"],
 
   // Inputs
-  panelName: 'panel-one',
+  panelName: "panel-one",
 
-  isActive: computed('activePanelName', 'panelName', function() {
-    return isEqual(this.get('activePanelName'), this.get('panelName'));
+  isActive: computed("activePanelName", "panelName", function() {
+    return isEqual(this.get("activePanelName"), this.get("panelName"));
   }),
   openOnInit: false,
   _activateDefaultPanel() {
-    if(this.isDestroying) { return; }
+    if (this.isDestroying) {
+      return;
+    }
 
-    if(this.get('openOnInit')) {
-      this.get('toggle')(this.get('panelName'));
+    if (this.get("openOnInit")) {
+      this.get("toggle")(this.get("panelName"));
     }
   },
 
   init() {
     this._super(...arguments);
     next(() => {
-      this.get('register')(this.get('panelName'));
+      this.get("register")(this.get("panelName"));
       this._activateDefaultPanel();
     });
   },
 
   willDestroyElement() {
-    this.get('unregister')(this.get('panelName'));
-  },
+    this.get("unregister")(this.get("panelName"));
+  }
 });
-
-AccordionPanelComponent.reopenClass({
-  positionalParams: ['activePanelName', 'toggle']
-});
-
-export default AccordionPanelComponent;

--- a/addon/components/accordion-toggle.js
+++ b/addon/components/accordion-toggle.js
@@ -1,31 +1,25 @@
-import Component from '@ember/component';
-import { computed } from '@ember/object';
-import { isEqual } from '@ember/utils';
-import layout from '../templates/components/accordion-toggle';
+import Component from "@ember/component";
+import { computed } from "@ember/object";
+import { isEqual } from "@ember/utils";
+import layout from "../templates/components/accordion-toggle";
 
-const AccordionToggleComponent = Component.extend({
+export default Component.extend({
   layout,
   classNames: ["AccordionToggle"],
-  classNameBindings: ['isActive', 'disabled'],
+  classNameBindings: ["isActive", "disabled"],
 
   // Input params
   disabled: null,
-  panelName: 'panel-one',
+  panelName: "panel-one",
 
-  isActive: computed('activePanelName', 'panelName', function() {
-    return isEqual(this.get('activePanelName'), this.get('panelName'));
+  isActive: computed("activePanelName", "panelName", function() {
+    return isEqual(this.get("activePanelName"), this.get("panelName"));
   }),
 
   click: function() {
-    if(!this.get('disabled')) {
-      this.get('toggle')(this.get('panelName'));
+    if (!this.get("disabled")) {
+      this.get("toggle")(this.get("panelName"));
     }
     return false;
   }
 });
-
-AccordionToggleComponent.reopenClass({
-  positionalParams: ['activePanelName', 'toggle']
-});
-
-export default AccordionToggleComponent;

--- a/addon/templates/components/accordion-item.hbs
+++ b/addon/templates/components/accordion-item.hbs
@@ -1,7 +1,12 @@
 {{yield
   (hash
-    toggle=(component 'accordion-toggle' activePanel (action 'togglePanel'))
-    panel=(component 'accordion-panel' activePanel (action 'togglePanel')
+    toggle=(component 'accordion-toggle'
+      activePanelName=this.activePanel
+      toggle=(action 'togglePanel')
+    )
+    panel=(component 'accordion-panel'
+      activePanelName=this.activePanel
+      toggle=(action 'togglePanel')
       register=(action register itemId)
       unregister=(action unregister itemId)
     )

--- a/addon/templates/components/accordion-list.hbs
+++ b/addon/templates/components/accordion-list.hbs
@@ -1,11 +1,12 @@
 {{yield
   (hash
-    item=(component 'accordion-item' _activeItems
-           toggle=(action 'toggleItem')
-           close=(action 'closeItem')
-           register=(action 'register')
-           unregister=(action 'unregister')
-         )
+    item=(component 'accordion-item'
+      activeItems=this._activeItems
+      toggle=(action 'toggleItem')
+      close=(action 'closeItem')
+      register=(action 'register')
+      unregister=(action 'unregister')
+    )
     expandAll=(action 'expandAll')
     collapseAll=(action 'collapseAll')
     allExpanded=allExpanded

--- a/tests/dummy/app/templates/home.hbs
+++ b/tests/dummy/app/templates/home.hbs
@@ -11,8 +11,6 @@
   a panel and <i>closes other sibling items</i>.
 </p>
 
-{{accordion-list items 'accordion-elements/toggle' 'accordion-elements/panel'}}
-
 <h2>Enhanced Behaviors</h2>
 <p>
   The {{#code-inline}}component:accordion-list{{/code-inline}} also supports some enhanced


### PR DESCRIPTION
This removes the internal use of positional params. These parameters were not intended to be part of the public interface so this should not be a breaking change.

Note that most of the changes here where made by prettier.